### PR TITLE
Add optional pattern to filter file types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ This GitHub action applies to pull requests and populates 3 output variables wit
   uses: futuratrepadeira/changed-files@v3.0.0
   with:
     repo-token: ${{ github.token }}
+    pattern: '^.*\.(md|markdown)$'
 ```
 
 ### Inputs
 * **`repo-token`**: GitHub Access Token
+* **`pattern`** (optional): A regular expression to filter the outputs by. Defaults to `'.*'`.
 
 ### Outputs
 All output values are a single JSON encoded array.

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
     required: true
+  pattern:
+    description: 'A regular expression to filter the outputs by.'
+    required: false
+    default: '.*'
 outputs:
   files_created:
     description: 'The names of the newly created files'

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,9 @@ async function getChangedFiles(client: github.GitHub, prNumber: number, fileCoun
                     changedFiles.updated.push(f.filename)
                 } else if (f.status === "renamed") {
                     changedFiles.created.push(f.filename)
-                    changedFiles.deleted.push(f["previous_filename"])
+                    if (re.test(f["previous_filename"])) {
+                        changedFiles.deleted.push(f["previous_filename"])
+                    }
                 }
             })
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,18 +23,22 @@ async function getChangedFiles(client: github.GitHub, prNumber: number, fileCoun
             per_page: fetchPerPage,
         })
 
-        listFilesResponse.data.forEach(f => {
-            if (f.status === "added") {
-                changedFiles.created.push(f.filename)
-            } else if (f.status === "removed") {
-                changedFiles.deleted.push(f.filename)
-            } else if (f.status === "modified") {
-                changedFiles.updated.push(f.filename)
-            } else if (f.status === "renamed") {
-                changedFiles.created.push(f.filename)
-                changedFiles.deleted.push(f["previous_filename"])
-            }
-        })
+        const pattern = core.getInput("pattern")
+        const re = new RegExp(pattern.length ? pattern : ".*")
+        listFilesResponse.data
+            .filter(f => re.test(f.filename))
+            .forEach(f => {
+                if (f.status === "added") {
+                    changedFiles.created.push(f.filename)
+                } else if (f.status === "removed") {
+                    changedFiles.deleted.push(f.filename)
+                } else if (f.status === "modified") {
+                    changedFiles.updated.push(f.filename)
+                } else if (f.status === "renamed") {
+                    changedFiles.created.push(f.filename)
+                    changedFiles.deleted.push(f["previous_filename"])
+                }
+            })
     }
     return changedFiles
 }


### PR DESCRIPTION
I really like this action, but I've found that I often want to filter the outputs that it produces and hand them to other tasks such as linters. This PR adds an optional `pattern` input which is a regex that defaults to `.*` that can be used to filter the files that end up in each array.

I haven't been able to build and test the changes so, if you like the PR, you might need to try it against a test project.