### PR TITLE
Add optional `pr-number` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This GitHub action applies to pull requests and populates 3 output variables wit
 ### Inputs
 * **`repo-token`**: GitHub Access Token
 * **`pattern`** (optional): A regular expression to filter the outputs by. Defaults to `'.*'`.
+* **`pr-number`** (optional): The pull request number. If not provided, the pull request is inferred from the given context. Useful for actions running outside the `pull_request` event context.
 
 ### Outputs
 All output values are a single JSON encoded array.
@@ -21,4 +22,3 @@ All output values are a single JSON encoded array.
 * **`files_created`**: Created files
 * **`files_updated`**: Updated files
 * **`files_deleted`**: Deleted files
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,9 +50,21 @@ async function run(): Promise<void> {
         const token = core.getInput("repo-token", { required: true })
         const client = new github.GitHub(token)
 
-        const pr = github.context.payload.pull_request
+        const prNumberInput = core.getInput("pr-number")
+        const pr = prNumberInput
+            ? (
+                  await client.pulls.get({
+                      owner: github.context.repo.owner,
+                      repo: github.context.repo.repo,
+                      pull_number: parseInt(prNumberInput, 10),
+                  })
+              ).data
+            : github.context.payload.pull_request
+
         if (!pr) {
-            core.setFailed("Could not get pull request number from context, exiting")
+            core.setFailed(
+                `Could not get pull request from ${prNumberInput ? "the provided pr number" : "context"}, exiting`,
+            )
             return
         }
 


### PR DESCRIPTION
### Description:

This optional input allows users to run this action outside of the `pull_request` event context.

### Reasoning:

Certain pipelines are not conducive to running solely inside the `pull_request` event. For example, we are creating a custom `deployment` event triggered by a Netlify webhook when the build succeeds on their end. After this event triggers, we'd then like to use the changed files of the PR alongside the deployed preview url.

⚠️ This code has not been tested outside of a few manual triggers. I will look to tighten that up if this is a desired addition to the codebase.