### PR TITLE
use github.token as default repo-token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
     repo-token:
         description: "The GITHUB_TOKEN secret"
         required: true
+        default: ${{ github.token }}
     pattern:
         description: "A regular expression to filter the outputs by."
         required: false


### PR DESCRIPTION
It would be great to use `${{ github.token }}` as default for the `repo-token` input.
Otherwise the repo-token must always be specified.

I think for most users the token is always `${{ github.token }}`.