### PR TITLE
feat: add changed output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
         required: false
         description: "The encoding for the output values, either 'string' (default) or 'json'."
 outputs:
+    changed:
+        description: "Indicates whether a file has changed (boolean)"
     files_created:
         description: "The names of the newly created files"
     files_updated:

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,14 @@ async function run(): Promise<void> {
 
     const encoder = getEncoder();
 
+    let hasChanged = false;
+    const totalModified =
+        changedFiles.created.length + changedFiles.updated.length + changedFiles.deleted.length;
+    if (totalModified > 0) {
+        hasChanged = true;
+    }
+
+    core.setOutput("changed", String(hasChanged));
     core.setOutput("files_created", encoder(changedFiles.created));
     core.setOutput("files_updated", encoder(changedFiles.updated));
     core.setOutput("files_deleted", encoder(changedFiles.deleted));


### PR DESCRIPTION
Add additional output if any changed files.

This new output will simplify to detect changes inside a GitHub workflow without other validation of the `files_*` output lists. 