### PR TITLE
switch action to run on node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
         description: "The sum of all `files_*_count` outputs"
 
 runs:
-    using: "node16"
+    using: "node20"
     main: "dist/index.js"
 branding:
     icon: "wind"


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
